### PR TITLE
feat: add offline fallback page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -80,8 +80,8 @@ const withPWA = withPWAInit({
      },
   ],
   fallbacks: {
-    // Optional: a custom offline page
-    // document: '/offline.html', 
+    // Página personalizada para usar cuando no hay conexión
+    document: '/offline.html',
   }
 });
 

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sin conexión</title>
+  <style>
+    body { display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: sans-serif; text-align: center; padding: 1rem; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    p { color: #555; }
+  </style>
+</head>
+<body>
+  <div>
+    <h1>Estás sin conexión</h1>
+    <p>La aplicación requiere acceso a internet. Por favor verifica tu conexión.</p>
+  </div>
+</body>
+</html>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,8 @@
+export default function OfflinePage() {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center p-4 text-center">
+      <h1 className="mb-2 text-2xl font-bold">Estás sin conexión</h1>
+      <p className="text-muted-foreground">La aplicación requiere acceso a internet. Por favor verifica tu conexión.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add offline page with user-facing offline message
- provide static offline.html and configure next-pwa fallback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires manual ESLint configuration)
- `npm run build`
- `grep -a -o -n -E '.{0,50}offline.html.{0,50}' public/sw.js`

------
https://chatgpt.com/codex/tasks/task_b_68bad82dd754832292238ac52bbc5431