### PR TITLE
feat: cache video tutorials for offline playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Video Cache
+
+Tutorial videos retrieved from Firebase Storage are cached using a **Cache First** strategy.
+The cache can store up to **20 videos** and each entry expires after **30 days**.
+This allows previously viewed videos to remain available offline while keeping storage usage under control.

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,22 @@ const withPWA = withPWAInit({
   skipWaiting: true,
   runtimeCaching: [
     {
+      // Strategy: Cache First (for Firebase-hosted videos)
+      // Stores tutorial videos for offline replay when available.
+      urlPattern: /^https?:\/\/firebasestorage\.googleapis\.com\/.*\.(?:mp4|webm|ogg)$/i,
+      handler: 'CacheFirst',
+      options: {
+        cacheName: 'video-cache',
+        expiration: {
+          maxEntries: 20,
+          maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+        },
+        cacheableResponse: {
+          statuses: [0, 200],
+        },
+      },
+    },
+    {
       // Strategy: Network First (for dynamic data from Firebase)
       // Tries the network first, then falls back to cache.
       // Essential for keeping phone numbers, etc., up-to-date.


### PR DESCRIPTION
## Summary
- cache Firebase-hosted videos with a Cache First strategy
- replace video link with inline player that reads from cache and shows offline message
- document video cache limits and expiration

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: missing module declarations and type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bade678a9c832296020acfc7748b5a