### PR TITLE
feat: add Dexie database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "dexie": "^4.2.0",
         "dotenv": "^16.5.0",
         "embla-carousel-react": "^8.6.0",
         "firebase": "^11.9.1",
@@ -9796,6 +9797,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nextn",
   "version": "0.1.0",
@@ -41,6 +40,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "dexie": "^4.2.0",
     "dotenv": "^16.5.0",
     "embla-carousel-react": "^8.6.0",
     "firebase": "^11.9.1",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,13 @@
+import Dexie from "dexie";
+
+export const db = new Dexie("emergencia");
+
+db.version(1).stores({
+  contacts: "id,updated_at,deleted",
+  protocols: "id,updated_at,deleted",
+  incidents: "id,updated_at,deleted",
+  attachments: "id,incidentId,updated_at,deleted",
+  outbox: "++id,type,payload,created_at",
+});
+
+export default db;


### PR DESCRIPTION
## Summary
- add Dexie dependency
- initialize Dexie database with tables for contacts, protocols, incidents, attachments and outbox

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bb288e816483228c7e92bc305ef254