### PR TITLE
Seed local database on app start

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { cn } from "@/lib/utils";
 import { Toaster } from "@/components/ui/toaster";
 import { RemoteConfigProvider } from "@/hooks/useRemoteConfig.tsx";
+import { SeedDB } from "@/components/SeedDB";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -98,6 +99,7 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
       </head>
       <body className={cn("min-h-screen bg-background font-body antialiased", inter.variable)}>
+        <SeedDB />
         <RemoteConfigProvider>
           {children}
         </RemoteConfigProvider>

--- a/src/components/SeedDB.tsx
+++ b/src/components/SeedDB.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useEffect } from 'react';
+import { seedDB } from '@/lib/db';
+
+export function SeedDB() {
+  useEffect(() => {
+    seedDB();
+  }, []);
+  return null;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,6 @@
 import Dexie from "dexie";
+import { CONTACT_DATA } from "@/lib/config";
+import { educationTopics } from "@/lib/data/educationData";
 
 export const db = new Dexie("emergencia");
 
@@ -9,5 +11,20 @@ db.version(1).stores({
   attachments: "id,incidentId,updated_at,deleted",
   outbox: "++id,type,payload,created_at",
 });
+
+const CONTACT_DATA_ARRAY = [
+  { id: "samco", ...CONTACT_DATA.samco },
+  { id: "monitoringCenter", ...CONTACT_DATA.monitoringCenter },
+  { id: "police", ...CONTACT_DATA.police },
+  { id: "firefighters", ...CONTACT_DATA.firefighters },
+  { id: "ambulance", ...CONTACT_DATA.ambulance },
+];
+
+export async function seedDB() {
+  await db.contacts.bulkPut(CONTACT_DATA_ARRAY);
+  await db.protocols.bulkPut(
+    educationTopics.map((topic) => ({ id: topic.slug, ...topic }))
+  );
+}
 
 export default db;


### PR DESCRIPTION
## Summary
- load contact and protocol data into Dexie database
- invoke seeding when the application layout renders

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_b_68bb324cae14832291cc1b37f2b5166d